### PR TITLE
Adding Support for AlphaVantage API Entitlements

### DIFF
--- a/classes/class-wpau-stock-ticker-settings.php
+++ b/classes/class-wpau-stock-ticker-settings.php
@@ -156,6 +156,7 @@ class Wpau_Stock_Ticker_Settings {
 				'items'       => array(
 					''    => esc_attr__( 'End of Day', 'stock-ticker' ),
 					'delayed'   => esc_attr__( '15 Minute Delay', 'stock-ticker' ),
+					'realtime'   => esc_attr__( 'Realtime', 'stock-ticker' ),
 				),
 				'value'       => $this->defaults['avapientitlement'],
 			)
@@ -796,8 +797,8 @@ class Wpau_Stock_Ticker_Settings {
 					}
 					break;
 				case 'avapientitlement':
-					if ( ! in_array( (string) $value, array( '', 'delayed' ), true ) ) {
-						$value = 5;
+					if ( ! in_array( (string) $value, array( '', 'delayed', 'realtime' ), true ) ) {
+						$value = '';
 					}
 					break;
 				case 'symbols':

--- a/classes/class-wpau-stock-ticker-settings.php
+++ b/classes/class-wpau-stock-ticker-settings.php
@@ -143,6 +143,23 @@ class Wpau_Stock_Ticker_Settings {
 				'value'       => $this->defaults['av_api_tier'],
 			)
 		);
+		
+		add_settings_field(
+			$this->option_name . 'avapientitlement',
+			__( 'API Entitlement', 'stock-ticker' ),
+			array( &$this, 'settings_field_select' ),
+			$this->slug,
+			'wpau_stock_ticker',
+			array(
+				'field'       => $this->option_name . '[avapientitlement]',
+				'description' => __( 'If you have applied for an entitlement through a premium API key, select the entitlement you would like to use. Otherwise, select End of Day.', 'stock-ticker' ),
+				'items'       => array(
+					''    => esc_attr__( 'End of Day', 'stock-ticker' ),
+					'delayed'   => esc_attr__( '15 Minute Delay', 'stock-ticker' ),
+				),
+				'value'       => $this->defaults['avapientitlement'],
+			)
+		);
 
 		add_settings_field(
 			$this->option_name . 'all_symbols',
@@ -775,6 +792,11 @@ class Wpau_Stock_Ticker_Settings {
 					break;
 				case 'av_api_tier':
 					if ( ! in_array( (int) $value, array( 5, 30, 75, 150, 300, 600, 1200 ), true ) ) {
+						$value = 5;
+					}
+					break;
+				case 'avapientitlement':
+					if ( ! in_array( (string) $value, array( '', 'delayed' ), true ) ) {
 						$value = 5;
 					}
 					break;

--- a/stock-ticker.php
+++ b/stock-ticker.php
@@ -36,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'WPAU_STOCK_TICKER_VER', '3.24.6' );
-define( 'WPAU_STOCK_TICKER_DB_VER', 11 );
+define( 'WPAU_STOCK_TICKER_DB_VER', 12 );
 define( 'WPAU_STOCK_TICKER_DIR', __DIR__ );
 define( 'WPAU_STOCK_TICKER_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'WPAU_STOCK_TICKER_PLUGIN_FILE', plugin_basename( __FILE__ ) );

--- a/update.php
+++ b/update.php
@@ -301,3 +301,14 @@ function au_stockticker_update_routine_11() {
 		}
 	}
 } // END function au_stockticker_update_routine_11()
+
+
+// Add entitlement setting
+function au_stockticker_update_routine_12() {
+	$defaults = get_option( 'stockticker_defaults' );
+	
+	if ( ! isset( $defaults['avapientitlement'] ) ) {
+		$defaults['avapientitlement'] = '';
+		update_option( 'stockticker_defaults', $defaults );
+	}
+} // END function au_stockticker_update_routine_12()


### PR DESCRIPTION
This patch adds a new option `avapientitlement` and setting to control whether an `entitlement` query string parameter is specified on the API URL. With the `entitlement=delayed` query string parameter, premium API keys with the entitlement enabled by AlphaVantage can query for 15 minute delayed data (or `entitlement=realtime` for realtime data). The default value is an empty string, which results in no entitlement parameter being added to the URL.

For completeness, the new setting field includes support for the `realtime` entitlement per [AlphaVantage's documentation](https://www.alphavantage.co/documentation/#latestprice). I do not have an account with the realtime entitlement enabled, so realtime data has not been tested. If AlphaVantage follows the same pattern of modifying the `Global Quote` key (e.g. the response key changes from "Global Quote" to "Global Quote - DATA DELAYED BY 15 MINUTES" when `entitlement=delayed` is specified), the update should be generic enough to handle any additional text added to the `Global Quote` key as long as the key contains "Global Quote".

This patch also updates the database version to 12 and includes an update function to add the `avapientitlement` option to `stockticker_defaults` as an empty string, which adds no entitlement to the API URL and should result in no changed behavior for existing users after upgrading.